### PR TITLE
ビューモデルの実装

### DIFF
--- a/Regional-Compatibility-Checker/Regional-Compatibility-Checker.xcodeproj/project.pbxproj
+++ b/Regional-Compatibility-Checker/Regional-Compatibility-Checker.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		41B8BCD72B4837EE00646B1B /* UserData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41B8BCD62B4837EE00646B1B /* UserData.swift */; };
 		41B8BCD92B48402000646B1B /* PrefectureData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41B8BCD82B48402000646B1B /* PrefectureData.swift */; };
 		41B8BCDC2B48676200646B1B /* APIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41B8BCDB2B48676200646B1B /* APIService.swift */; };
+		41D9850B2B49AAF800C1CD62 /* UserPrefectureViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D9850A2B49AAF800C1CD62 /* UserPrefectureViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -25,6 +26,7 @@
 		41B8BCD62B4837EE00646B1B /* UserData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserData.swift; sourceTree = "<group>"; };
 		41B8BCD82B48402000646B1B /* PrefectureData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefectureData.swift; sourceTree = "<group>"; };
 		41B8BCDB2B48676200646B1B /* APIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIService.swift; sourceTree = "<group>"; };
+		41D9850A2B49AAF800C1CD62 /* UserPrefectureViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPrefectureViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -57,6 +59,7 @@
 		416AE5962B46D63B0089039A /* Regional-Compatibility-Checker */ = {
 			isa = PBXGroup;
 			children = (
+				41D985092B49A25000C1CD62 /* ViewModel */,
 				41B8BCDA2B4866C400646B1B /* Services */,
 				41B8BCD52B4837C200646B1B /* Models */,
 				416AE5972B46D63B0089039A /* Regional_Compatibility_CheckerApp.swift */,
@@ -98,6 +101,14 @@
 				41B8BCDB2B48676200646B1B /* APIService.swift */,
 			);
 			path = Services;
+			sourceTree = "<group>";
+		};
+		41D985092B49A25000C1CD62 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				41D9850A2B49AAF800C1CD62 /* UserPrefectureViewModel.swift */,
+			);
+			path = ViewModel;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -170,6 +181,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				41D9850B2B49AAF800C1CD62 /* UserPrefectureViewModel.swift in Sources */,
 				416AE59A2B46D63B0089039A /* ContentView.swift in Sources */,
 				41B8BCDC2B48676200646B1B /* APIService.swift in Sources */,
 				416AE5982B46D63B0089039A /* Regional_Compatibility_CheckerApp.swift in Sources */,

--- a/Regional-Compatibility-Checker/Regional-Compatibility-Checker.xcodeproj/project.pbxproj
+++ b/Regional-Compatibility-Checker/Regional-Compatibility-Checker.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		413B03522B4C581300E95412 /* ImageDownloadService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413B03512B4C581300E95412 /* ImageDownloadService.swift */; };
 		416AE5982B46D63B0089039A /* Regional_Compatibility_CheckerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416AE5972B46D63B0089039A /* Regional_Compatibility_CheckerApp.swift */; };
 		416AE59A2B46D63B0089039A /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416AE5992B46D63B0089039A /* ContentView.swift */; };
 		416AE59C2B46D63C0089039A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 416AE59B2B46D63C0089039A /* Assets.xcassets */; };
@@ -18,6 +19,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		413B03512B4C581300E95412 /* ImageDownloadService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDownloadService.swift; sourceTree = "<group>"; };
 		416AE5942B46D63B0089039A /* Regional-Compatibility-Checker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Regional-Compatibility-Checker.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		416AE5972B46D63B0089039A /* Regional_Compatibility_CheckerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Regional_Compatibility_CheckerApp.swift; sourceTree = "<group>"; };
 		416AE5992B46D63B0089039A /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -99,6 +101,7 @@
 			isa = PBXGroup;
 			children = (
 				41B8BCDB2B48676200646B1B /* APIService.swift */,
+				413B03512B4C581300E95412 /* ImageDownloadService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -186,6 +189,7 @@
 				41B8BCDC2B48676200646B1B /* APIService.swift in Sources */,
 				416AE5982B46D63B0089039A /* Regional_Compatibility_CheckerApp.swift in Sources */,
 				41B8BCD92B48402000646B1B /* PrefectureData.swift in Sources */,
+				413B03522B4C581300E95412 /* ImageDownloadService.swift in Sources */,
 				41B8BCD72B4837EE00646B1B /* UserData.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Regional-Compatibility-Checker/Regional-Compatibility-Checker/Models/PrefectureData.swift
+++ b/Regional-Compatibility-Checker/Regional-Compatibility-Checker/Models/PrefectureData.swift
@@ -32,3 +32,16 @@ struct PrefectureData: Codable {
           case brief
       }
 }
+
+// レスポンスのデータの整形を行う関数
+// MARK: - extension PrefectureData
+extension PrefectureData {
+  var formattedCitizenDay: String {
+    guard let citizenDay = citizenDay else { return "県民の日はありません。"}
+    return "\(citizenDay.month)月\(citizenDay.date)日"
+  }
+  
+  var formattedHasCoastLine: String {
+    return hasCoastLine ? "海岸線あり" : "海岸線なし"
+  }
+}

--- a/Regional-Compatibility-Checker/Regional-Compatibility-Checker/Services/APIService.swift
+++ b/Regional-Compatibility-Checker/Regional-Compatibility-Checker/Services/APIService.swift
@@ -53,7 +53,7 @@ class APIService {
       
       do {
         if let dataString = String(data: data, encoding: .utf8) {
-             print("受信データ: \(dataString)")
+//             print("受信データ: \(dataString)")
          }
         let prefectureData = try JSONDecoder().decode(PrefectureData.self, from: data)
         completion(.success(prefectureData))

--- a/Regional-Compatibility-Checker/Regional-Compatibility-Checker/Services/ImageDownloadService.swift
+++ b/Regional-Compatibility-Checker/Regional-Compatibility-Checker/Services/ImageDownloadService.swift
@@ -1,0 +1,30 @@
+//
+//  ImageDownloadService.swift
+//  Regional-Compatibility-Checker
+//
+//  Created by k21123kk on 2024/01/09.
+//
+
+import Foundation
+import UIKit
+
+class ImageDownloadService {
+  func downloadImage(from urlString: String, completion: @escaping (Result<UIImage, Error>) -> Void) {
+         guard let url = URL(string: urlString) else {
+             completion(.failure(NSError(domain: "InvalidURL", code: -1, userInfo: nil)))
+             return
+         }
+
+         URLSession.shared.dataTask(with: url) { data, response, error in
+             if let error = error {
+                 completion(.failure(error))
+                 return
+             }
+             guard let data = data, let image = UIImage(data: data) else {
+                 completion(.failure(NSError(domain: "ImageDataError", code: -2, userInfo: nil)))
+                 return
+             }
+             completion(.success(image))
+         }.resume()
+     }
+}

--- a/Regional-Compatibility-Checker/Regional-Compatibility-Checker/ViewModel/UserPrefectureViewModel.swift
+++ b/Regional-Compatibility-Checker/Regional-Compatibility-Checker/ViewModel/UserPrefectureViewModel.swift
@@ -1,0 +1,84 @@
+//
+//  UserPrefectureViewModel.swift
+//  Regional-Compatibility-Checker
+//
+//  Created by k21123kk on 2024/01/07.
+//
+
+import Foundation
+
+class UserPrefectureViewModel: ObservableObject {
+  @Published var userData: UserData
+  @Published var prefectureData: PrefectureData?
+  @Published var isLoading: Bool = false
+  @Published var errorMessage: String?
+  
+  private var apiService: APIService
+  
+  init(apiService: APIService = APIService()) {
+    self.apiService = apiService
+    self.userData = UserData(name: "", birthday: YearMonthDay(year: 0, month: 1, day: 1), bloodType: "", today: YearMonthDay(year: 0, month: 0, day: 0))
+  }
+  
+  // MARK: - fetchPrefectureData()
+  // APIリクエストを実装し、結果をハンドリングするメソッド
+  func fetchPrefectureData() {
+    guard validateUserData(userData: self.userData) else {
+      self.errorMessage = "入力内容を確認してください。"
+      return
+    }
+    self.isLoading = true
+    self.errorMessage = nil
+    
+    // 現在時刻を取得
+    let now = Date()
+    let calendar = Calendar(identifier: .gregorian)
+    let year = calendar.component(.year, from: now)
+    let month = calendar.component(.month, from: now)
+    let day = calendar.component(.day, from: now)
+    
+    self.userData.today = YearMonthDay(year: year, month: month, day: day)
+    apiService.postUserData(userData: self.userData) { [weak self] result in  // [weak self]を使って循環参照を防ぐ
+      DispatchQueue.main.async {
+        self?.isLoading = false
+        switch result {
+        case .success(let data):
+          self?.prefectureData = data
+        case .failure(let error):
+          self?.errorMessage = error.localizedDescription
+        }
+      }
+    }
+  }
+  
+  // ユーザー情報のバリデーションチェック
+  // MARK: - validateUserData()
+  func validateUserData(userData: UserData) -> Bool {
+    if userData.name.isEmpty {
+      self.errorMessage = "名前を入力してください"
+      return false
+    }
+    
+    if userData.birthday.year == 0 || userData.birthday.month == 0 || userData.birthday.day == 0 {
+      self.errorMessage = "生年月日を入力してください"
+      return false
+    }
+    
+    if userData.bloodType.isEmpty {
+      self.errorMessage = "血液型を入力してください"
+      return false
+    }
+    
+    return true
+  }
+  
+  // prefectureDataをビューから使いやすいように必要なデータ形式に変換
+  // MARK: - getPrefectureData()
+  func getPrefectureData() -> PrefectureData? {
+    guard let prefectureData = self.prefectureData else { return nil }
+    
+    return prefectureData
+  }
+  
+  
+}

--- a/Regional-Compatibility-Checker/Regional-Compatibility-Checker/ViewModel/UserPrefectureViewModel.swift
+++ b/Regional-Compatibility-Checker/Regional-Compatibility-Checker/ViewModel/UserPrefectureViewModel.swift
@@ -57,12 +57,24 @@ class UserPrefectureViewModel: ObservableObject {
         case .success(let data):
           self?.prefectureData = data
         case .failure(let error):
-          self?.errorMessage = error.localizedDescription
+          self?.handleError(error)
         }
       }
     }
   }
   
+  private func handleError(_ error: Error) {
+      if let urlError = error as? URLError {
+          switch urlError.code {
+          case .notConnectedToInternet:
+              self.errorMessage = "インターネット接続がありません。"
+          default:
+              self.errorMessage = "ネットワークエラーが発生しました。"
+          }
+      } else {
+          self.errorMessage = "データの取得に失敗しました。"
+      }
+  }
 
   
   // ユーザー名のバリデーションを行うメソッド
@@ -141,7 +153,7 @@ class UserPrefectureViewModel: ObservableObject {
     }
     
     URLSession.shared.dataTask(with: url) { [weak self] data, response, error in  // [weak self]を使って循環参照を防ぐ
-      if let error = error {
+      if error != nil {
 //        print("画像のダウンロードに失敗しました: ", error.localizedDescription)
         self?.errorMessage = "画像のダウンロードに失敗しました。"
         return

--- a/Regional-Compatibility-Checker/Regional-Compatibility-Checker/ViewModel/UserPrefectureViewModel.swift
+++ b/Regional-Compatibility-Checker/Regional-Compatibility-Checker/ViewModel/UserPrefectureViewModel.swift
@@ -17,6 +17,11 @@ class UserPrefectureViewModel: ObservableObject {
       }
     }
   }
+  @Published var selectedDate: Date = Date() {  // DatePickerで使うユーザーの生年月日
+          didSet {
+              userData.birthday = convertDateToYearMonthDay(date: selectedDate)
+          }
+      }
   
   @Published var isLoading: Bool = false // APIリクエスト中かどうか
   @Published var errorMessage: String? // エラーメッセージ
@@ -41,8 +46,21 @@ class UserPrefectureViewModel: ObservableObject {
     case unknown
   }
   
-  // MARK: - fetchPrefectureData()
+  
+  // Date型をYearMonthDay型に変換するメソッド
+  // MARK: - convertDateToYearMonthDay()
+  func convertDateToYearMonthDay(date: Date) -> YearMonthDay {
+      let calendar = Calendar.current
+      let year = calendar.component(.year, from: date)
+      let month = calendar.component(.month, from: date)
+      let day = calendar.component(.day, from: date)
+
+      return YearMonthDay(year: year, month: month, day: day)
+  }
+
+  
   // APIリクエストを実装し、結果をハンドリングするメソッド
+  // MARK: - fetchPrefectureData()
   func fetchPrefectureData() {
     self.isLoading = true
     self.errorMessage = nil
@@ -68,8 +86,11 @@ class UserPrefectureViewModel: ObservableObject {
         }
       }
     }
-  }
+  } // -> fetchPrefectureData()
   
+  
+  // URLSessionに関わるエラーをハンドリングするメソッド
+  // MARK: - handleError()
   private func handleError(_ error: Error) {
     // URLErrorのハンドリング
     if let urlError = error as? URLError {
@@ -95,8 +116,7 @@ class UserPrefectureViewModel: ObservableObject {
     else {
       self.errorMessage = "データの取得に失敗しました。"
     }
-  }
-  
+  }  // -> handleError()
   
   
   // ユーザー名のバリデーションを行うメソッド
@@ -110,6 +130,7 @@ class UserPrefectureViewModel: ObservableObject {
     
     return
   }
+  
   
   // 誕生日のバリデーションを行うメソッド
   // MARK: - validateBirthday()
@@ -127,19 +148,18 @@ class UserPrefectureViewModel: ObservableObject {
       self.birthdayErrorMessage = "誕生日を入力してください。"
       return
     }
-    
     // 日付の形式が正しいかどうかのチェック
     guard let birthdayDate = calendar.date(from: dateComponents) else {
       self.birthdayErrorMessage = "無効な日付です。"
       return
     }
-    
     // 誕生日が未来の日付でないかのチェック
     if birthdayDate > currentDate {
       self.birthdayErrorMessage = "誕生日が未来の日付です。"
       return
     }
-  }
+  }  // -> validateBirthday()
+  
   
   // 血液型のバリデーションを行うメソッド
   // MARK: - validateBloodType()
@@ -156,6 +176,7 @@ class UserPrefectureViewModel: ObservableObject {
     return
   }
   
+  
   // 全てのユーザー情報のバリデーションを行うメソッド
   // MARK: - validateAllFields()
   func validateAllFields() -> Bool {
@@ -164,6 +185,7 @@ class UserPrefectureViewModel: ObservableObject {
     validateBloodType()
     return nameErrorMessage == nil && birthdayErrorMessage == nil && bloodTypeErrorMessage == nil  // エラーメッセージが全てnilであればtrueを返す
   }
+  
   
   // prefectureDataのlogoUrlの県のイラストをダウンロードする
   // MARK: - downloadPrefectureImage()
@@ -180,4 +202,4 @@ class UserPrefectureViewModel: ObservableObject {
     }
   }
   
-}
+}  // -> UserDataViewModel class

--- a/Regional-Compatibility-Checker/Regional-Compatibility-Checker/ViewModel/UserPrefectureViewModel.swift
+++ b/Regional-Compatibility-Checker/Regional-Compatibility-Checker/ViewModel/UserPrefectureViewModel.swift
@@ -6,12 +6,26 @@
 //
 
 import Foundation
+import UIKit
 
 class UserPrefectureViewModel: ObservableObject {
-  @Published var userData: UserData
-  @Published var prefectureData: PrefectureData?
-  @Published var isLoading: Bool = false
-  @Published var errorMessage: String?
+  @Published var userData: UserData // ユーザー情報
+  @Published var prefectureData: PrefectureData? { // APIのレスポンスデータ
+    didSet { // prefectureDataが更新されたら、ロゴ（イラスト）をダウンロードする
+      if let logoUrl = prefectureData?.logoUrl {
+        downloadPrefectureImage(from: logoUrl)
+      }
+    }
+  }
+  
+  @Published var isLoading: Bool = false // APIリクエスト中かどうか
+  @Published var errorMessage: String? // エラーメッセージ
+  @Published var nameErrorMessage: String? // 名前のエラーメッセージ
+  @Published var birthdayErrorMessage: String? // 誕生日のエラーメッセージ
+  @Published var bloodTypeErrorMessage: String? // 血液型のエラーメッセージ
+  
+  @Published var downloadedImage: UIImage? // 県のロゴ（イラスト）
+
   
   private var apiService: APIService
   
@@ -23,10 +37,6 @@ class UserPrefectureViewModel: ObservableObject {
   // MARK: - fetchPrefectureData()
   // APIリクエストを実装し、結果をハンドリングするメソッド
   func fetchPrefectureData() {
-    guard validateUserData(userData: self.userData) else {
-      self.errorMessage = "入力内容を確認してください。"
-      return
-    }
     self.isLoading = true
     self.errorMessage = nil
     
@@ -36,10 +46,12 @@ class UserPrefectureViewModel: ObservableObject {
     let year = calendar.component(.year, from: now)
     let month = calendar.component(.month, from: now)
     let day = calendar.component(.day, from: now)
+
+    self.userData.today = YearMonthDay(year: year, month: month, day: day)  // ユーザー情報(today)に現在時刻をセット
     
-    self.userData.today = YearMonthDay(year: year, month: month, day: day)
     apiService.postUserData(userData: self.userData) { [weak self] result in  // [weak self]を使って循環参照を防ぐ
-      DispatchQueue.main.async {
+      
+      DispatchQueue.main.async {  //メインスレッドで実行
         self?.isLoading = false
         switch result {
         case .success(let data):
@@ -51,34 +63,95 @@ class UserPrefectureViewModel: ObservableObject {
     }
   }
   
-  // ユーザー情報のバリデーションチェック
-  // MARK: - validateUserData()
-  func validateUserData(userData: UserData) -> Bool {
+
+  
+  // ユーザー名のバリデーションを行うメソッド
+  // MARK: - validateName()
+  func validateName() {
     if userData.name.isEmpty {
-      self.errorMessage = "名前を入力してください"
-      return false
+      nameErrorMessage = "名前を入力してください。"
+    } else {
+      nameErrorMessage = nil
     }
     
+    return
+  }
+  
+  // 誕生日のバリデーションを行うメソッド
+  // MARK: - validateBirthday()
+  func validateBirthday() {
+    self.birthdayErrorMessage = nil
+    
+    let calendar = Calendar(identifier: .gregorian)
+    let currentDate = Date()
+    var dateComponents = DateComponents()
+    dateComponents.year = userData.birthday.year
+    dateComponents.month = userData.birthday.month
+    dateComponents.day = userData.birthday.day
+    // 誕生日が未入力の場合のチェック
     if userData.birthday.year == 0 || userData.birthday.month == 0 || userData.birthday.day == 0 {
-      self.errorMessage = "生年月日を入力してください"
-      return false
+      self.birthdayErrorMessage = "誕生日を入力してください。"
+      return
     }
-    
+
+    // 日付の形式が正しいかどうかのチェック
+    guard let birthdayDate = calendar.date(from: dateComponents) else {
+      self.birthdayErrorMessage = "無効な日付です。"
+      return
+    }
+
+    // 誕生日が未来の日付でないかのチェック
+    if birthdayDate > currentDate {
+      self.birthdayErrorMessage = "誕生日が未来の日付です。"
+      return
+    }
+  }
+  
+  // 血液型のバリデーションを行うメソッド
+  // MARK: - validateBloodType()
+  func validateBloodType() {
     if userData.bloodType.isEmpty {
-      self.errorMessage = "血液型を入力してください"
-      return false
+      bloodTypeErrorMessage = "血液型を入力してください。"
+    } else if !["a", "b", "o", "ab"].contains(userData.bloodType) {  // 入力された血液型がA, B, O, ABのいずれかでない場合
+      bloodTypeErrorMessage = "A, B, O, ABのいずれかを入力してください。"
+    }
+    else {
+      bloodTypeErrorMessage = nil
     }
     
-    return true
+    return
   }
   
-  // prefectureDataをビューから使いやすいように必要なデータ形式に変換
-  // MARK: - getPrefectureData()
-  func getPrefectureData() -> PrefectureData? {
-    guard let prefectureData = self.prefectureData else { return nil }
+  // 全てのユーザー情報のバリデーションを行うメソッド
+  // MARK: - validateAllFields()
+  func validateAllFields() -> Bool {
+          validateName()
+          validateBirthday()
+          validateBloodType()
+    return nameErrorMessage == nil && birthdayErrorMessage == nil && bloodTypeErrorMessage == nil  // エラーメッセージが全てnilであればtrueを返す
+    }
+  
+  // prefectureDataのlogoUrlの県のイラストをダウンロードする
+  // MARK: - downloadPrefectureImage()
+  func downloadPrefectureImage(from urlString: String) {
+    guard let url = URL(string: urlString) else {  // URLが有効かどうかのチェック
+//      print("URLが無効です")
+      errorMessage = "URLが無効です。"
+      return
+    }
     
-    return prefectureData
+    URLSession.shared.dataTask(with: url) { [weak self] data, response, error in  // [weak self]を使って循環参照を防ぐ
+      if let error = error {
+//        print("画像のダウンロードに失敗しました: ", error.localizedDescription)
+        self?.errorMessage = "画像のダウンロードに失敗しました。"
+        return
+      }
+      if let data = data, let image = UIImage(data: data) {  // 画像のダウンロードに成功した場合
+                      DispatchQueue.main.async {  // メインスレッドで実行
+                          self?.downloadedImage = image
+                      }
+                  }
+    }.resume()  // 非同期で画像をダウンロード
   }
-  
   
 }

--- a/Regional-Compatibility-Checker/Regional-Compatibility-Checker/ViewModel/UserPrefectureViewModel.swift
+++ b/Regional-Compatibility-Checker/Regional-Compatibility-Checker/ViewModel/UserPrefectureViewModel.swift
@@ -24,12 +24,13 @@ class UserPrefectureViewModel: ObservableObject {
       }
   
   @Published var isLoading: Bool = false // APIリクエスト中かどうか
+  @Published var isAlertPresented: Bool = false // アラートを表示するかどうか
   @Published var errorMessage: String? // エラーメッセージ
   @Published var nameErrorMessage: String? // 名前のエラーメッセージ
   @Published var birthdayErrorMessage: String? // 誕生日のエラーメッセージ
   @Published var bloodTypeErrorMessage: String? // 血液型のエラーメッセージ
   
-  @Published var downloadedImage: UIImage? // 県のロゴ（イラスト）
+  @Published var downloadedImage: UIImage? // logoUrlカラ取得してきた県のロゴ（イラスト）
   
   
   private var apiService: APIService
@@ -116,6 +117,7 @@ class UserPrefectureViewModel: ObservableObject {
     else {
       self.errorMessage = "データの取得に失敗しました。"
     }
+    self.isAlertPresented = true
   }  // -> handleError()
   
   

--- a/Regional-Compatibility-Checker/Regional-Compatibility-Checker/Views/ContentView.swift
+++ b/Regional-Compatibility-Checker/Regional-Compatibility-Checker/Views/ContentView.swift
@@ -13,26 +13,37 @@ struct ContentView: View {
   let birthday = YearMonthDay(year: 2000, month: 1, day: 27)
   let today = YearMonthDay(year: 2023, month: 5, day: 5)
 //  let userData = UserData(name: "ゆめみん", birthday: birthday, bloodType: "AB", today: today)
+  
+  @StateObject var viewModel: UserPrefectureViewModel = UserPrefectureViewModel()
 
     var body: some View {
-      Button(action: {
-        apiService.postUserData(userData: UserData(name: "晴登", birthday: self.birthday, bloodType: "a", today: self.today)
-        ) { result in
-          switch result {
-          case .success(let prefectureData):
-            print(prefectureData)
-            self.result = prefectureData
-            print("通信が成功しました")
-          case .failure(let error):
-            print(error)
-            print("エラーが発生しました")
+      VStack {
+        Button(action: {
+          apiService.postUserData(userData: UserData(name: "晴登", birthday: self.birthday, bloodType: "a", today: self.today)
+          ) { result in
+            switch result {
+            case .success(let prefectureData):
+              print(prefectureData)
+              self.result = prefectureData
+              print("通信が成功しました")
+            case .failure(let error):
+              print(error)
+              print("エラーが発生しました")
+            }
           }
+          print("ボタンが押されました")
+        }) {
+          Text("占い")
         }
-        print("ボタンが押されました")
-      }) {
-        Text("占い")
+        Text(result.name)
+        
+        if let image = viewModel.downloadedImage {
+                    Image(uiImage: image)
+                        // 画像の表示設定
+                } else {
+                    Text("No Image")
+                }
       }
-      Text(result.name)
     }
 }
 

--- a/Regional-Compatibility-Checker/Regional-Compatibility-Checker/Views/ContentView.swift
+++ b/Regional-Compatibility-Checker/Regional-Compatibility-Checker/Views/ContentView.swift
@@ -27,8 +27,8 @@ struct ContentView: View {
               self.result = prefectureData
               print("通信が成功しました")
             case .failure(let error):
+              print("エラーが発生しました:")
               print(error)
-              print("エラーが発生しました")
             }
           }
           print("ボタンが押されました")


### PR DESCRIPTION
# 概要
ビューとモデル(サービス層含む)の間のデータとロジックの仲介を行う関数およびプロパティの実装

# 内容
## 実装したビューモデルの役割
- ビューのユーザー情報の保持
- ビューに表示する占い結果のデータ保持
- 通信およびバリデーションチェックにかかわるエラーメッセージの保持
- サービス層のAPIリクエスト処理の呼び出し
- レスポンスデータ内のlogoUrlから画像をダウンロードする処理
- 通信エラーのハンドリング
- ビューの状態管理
    - isLoading
    - isAlertPresented
- 入力情報のバリデーションチェック

## メモ
小規模アプリなので関数のテストのしやすさより関数の使い方を重視したためビューモデルないの関数は直接ビューモデル内部のプロパティにアクセスして処理を行うようにした。
また、各処理の責務を適切に分離することを意識した。